### PR TITLE
Fix: Handle process exit code correctly in BuildProcessHelper

### DIFF
--- a/Tests/UKSF.Api.Modpack.Tests/BuildProcessHelperTests.cs
+++ b/Tests/UKSF.Api.Modpack.Tests/BuildProcessHelperTests.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading;
+using FluentAssertions;
+using Moq;
+using UKSF.Api.Core.Services;
+using UKSF.Api.Modpack.BuildProcess;
+using UKSF.Api.Core.Models;
+using Xunit;
+
+namespace UKSF.Api.Modpack.Tests
+{
+    public class BuildProcessHelperTests
+    {
+        private readonly Mock<IStepLogger> _mockStepLogger;
+        private readonly Mock<IUksfLogger> _mockUksfLogger;
+        private readonly CancellationTokenSource _cancellationTokenSource;
+
+        public BuildProcessHelperTests()
+        {
+            _mockStepLogger = new Mock<IStepLogger>();
+            _mockUksfLogger = new Mock<IUksfLogger>();
+            _cancellationTokenSource = new CancellationTokenSource();
+        }
+
+        [Fact]
+        public void Run_Should_ThrowException_WithCorrectExitCode_When_ProcessExitsWithNonZeroCode()
+        {
+            // Arrange
+            var buildProcessHelper = new BuildProcessHelper(
+                _mockStepLogger.Object,
+                _mockUksfLogger.Object,
+                _cancellationTokenSource,
+                suppressOutput: true, // Suppress console output for cleaner test logs
+                raiseErrors: true      // Ensure errors are raised for this test
+            );
+
+            string executable;
+            string args;
+            // For now, assume Windows for cmd.exe. Worker environment might need adjustment.
+            // Ideally, this would use platform detection or a cross-platform script.
+            if (Environment.OSVersion.Platform == PlatformID.Win32NT)
+            {
+                executable = "cmd.exe";
+                args = "/c \"exit 42\"";
+            }
+            else
+            {
+                executable = "sh";
+                args = "-c \"exit 42\"";
+            }
+
+            var workingDirectory = "."; // Current directory
+            var timeout = 5000;       // 5 seconds
+
+            // Act & Assert
+            var exception = Assert.Throws<Exception>(() =>
+                buildProcessHelper.Run(workingDirectory, executable, args, timeout)
+            );
+
+            exception.Message.Should().Contain("Process failed with exit code 42");
+
+            // Verify logs if necessary, for example, that an error was logged
+            // _mockUksfLogger.Verify(logger => logger.LogError(It.Is<string>(s => s.Contains("Build process exit code was non-zero (42)"))), Times.AtLeastOnce());
+        }
+    }
+}

--- a/Tests/UKSF.Api.Modpack.Tests/BuildProcessHelperTests.cs
+++ b/Tests/UKSF.Api.Modpack.Tests/BuildProcessHelperTests.cs
@@ -1,68 +1,54 @@
 using System;
-using System.Collections.Generic;
-using System.Diagnostics;
 using System.Threading;
 using FluentAssertions;
 using Moq;
-using UKSF.Api.Core.Services;
+using UKSF.Api.Core;
 using UKSF.Api.Modpack.BuildProcess;
-using UKSF.Api.Core.Models;
 using Xunit;
 
-namespace UKSF.Api.Modpack.Tests
+namespace UKSF.Api.Modpack.Tests;
+
+public class BuildProcessHelperTests
 {
-    public class BuildProcessHelperTests
+    private readonly CancellationTokenSource _cancellationTokenSource = new();
+    private readonly Mock<IStepLogger> _mockStepLogger = new();
+    private readonly Mock<IUksfLogger> _mockUksfLogger = new();
+
+    [Fact]
+    public void Run_Should_ThrowException_WithCorrectExitCode_When_ProcessExitsWithNonZeroCode()
     {
-        private readonly Mock<IStepLogger> _mockStepLogger;
-        private readonly Mock<IUksfLogger> _mockUksfLogger;
-        private readonly CancellationTokenSource _cancellationTokenSource;
+        // Arrange
+        var buildProcessHelper = new BuildProcessHelper(
+            _mockStepLogger.Object,
+            _mockUksfLogger.Object,
+            _cancellationTokenSource,
+            true // Ensure errors are raised for this test
+        );
 
-        public BuildProcessHelperTests()
+        string executable;
+        string args;
+        // For now, assume Windows for cmd.exe. Worker environment might need adjustment.
+        // Ideally, this would use platform detection or a cross-platform script.
+        if (Environment.OSVersion.Platform == PlatformID.Win32NT)
         {
-            _mockStepLogger = new Mock<IStepLogger>();
-            _mockUksfLogger = new Mock<IUksfLogger>();
-            _cancellationTokenSource = new CancellationTokenSource();
+            executable = "cmd.exe";
+            args = "/c \"exit 42\"";
+        }
+        else
+        {
+            executable = "sh";
+            args = "-c \"exit 42\"";
         }
 
-        [Fact]
-        public void Run_Should_ThrowException_WithCorrectExitCode_When_ProcessExitsWithNonZeroCode()
-        {
-            // Arrange
-            var buildProcessHelper = new BuildProcessHelper(
-                _mockStepLogger.Object,
-                _mockUksfLogger.Object,
-                _cancellationTokenSource,
-                suppressOutput: true, // Suppress console output for cleaner test logs
-                raiseErrors: true      // Ensure errors are raised for this test
-            );
+        var workingDirectory = "."; // Current directory
+        var timeout = 5000; // 5 seconds
 
-            string executable;
-            string args;
-            // For now, assume Windows for cmd.exe. Worker environment might need adjustment.
-            // Ideally, this would use platform detection or a cross-platform script.
-            if (Environment.OSVersion.Platform == PlatformID.Win32NT)
-            {
-                executable = "cmd.exe";
-                args = "/c \"exit 42\"";
-            }
-            else
-            {
-                executable = "sh";
-                args = "-c \"exit 42\"";
-            }
+        // Act & Assert
+        var exception = Assert.Throws<Exception>(() => buildProcessHelper.Run(workingDirectory, executable, args, timeout));
 
-            var workingDirectory = "."; // Current directory
-            var timeout = 5000;       // 5 seconds
+        exception.Message.Should().Contain("Process failed with exit code 42");
 
-            // Act & Assert
-            var exception = Assert.Throws<Exception>(() =>
-                buildProcessHelper.Run(workingDirectory, executable, args, timeout)
-            );
-
-            exception.Message.Should().Contain("Process failed with exit code 42");
-
-            // Verify logs if necessary, for example, that an error was logged
-            // _mockUksfLogger.Verify(logger => logger.LogError(It.Is<string>(s => s.Contains("Build process exit code was non-zero (42)"))), Times.AtLeastOnce());
-        }
+        // Verify logs if necessary, for example, that an error was logged
+        // _mockUksfLogger.Verify(logger => logger.LogError(It.Is<string>(s => s.Contains("Build process exit code was non-zero (42)"))), Times.AtLeastOnce());
     }
 }


### PR DESCRIPTION
The previous implementation had a potential race condition where the process object could be disposed before its ExitCode was read, leading to an "Process must exit before requested information can be determined" error.

This commit addresses the issue by:
1. Caching the ExitCode in a private field within the `Kill` method as soon as the process has exited and before it's disposed. This ensures the exit code is captured even if the `Exited` event fires and disposes the process object concurrently.
2. Modifying the `Run` method to use this cached `_exitCode` for all checks and logging, preventing errors if the main `_process` object is disposed.
3. Correcting `_process.EnableRaisingEvents = true` (was `false`). This is critical for the `Exited` event to fire reliably, which in turn ensures the `Kill` method is called and the exit code is cached as intended.
4. Adding a unit test to verify that non-zero exit codes are correctly captured and reported in exceptions.

These changes improve the robustness of the modpack build process by ensuring reliable capture and handling of process exit codes.