### PR TITLE
fix(scheduler): anchor UK-time scheduled actions to UTC across DST

### DIFF
--- a/Tests/UKSF.Api.Core.Tests/Common/ClockTests.cs
+++ b/Tests/UKSF.Api.Core.Tests/Common/ClockTests.cs
@@ -30,4 +30,40 @@ public class ClockTests
 
         subject.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromMilliseconds(10));
     }
+
+    [Theory]
+    // GMT (winter): UK time == UTC
+    [InlineData("2026-02-27T03:00:00Z", new[] { 6, 18 }, "2026-02-27T06:00:00Z")]
+    [InlineData("2026-02-27T10:00:00Z", new[] { 6, 18 }, "2026-02-27T18:00:00Z")]
+    [InlineData("2026-02-27T22:00:00Z", new[] { 6, 18 }, "2026-02-28T06:00:00Z")]
+    // BST (summer): UK time == UTC + 1
+    [InlineData("2026-04-06T03:00:00Z", new[] { 6, 18 }, "2026-04-06T05:00:00Z")]
+    [InlineData("2026-04-06T10:00:00Z", new[] { 6, 18 }, "2026-04-06T17:00:00Z")]
+    [InlineData("2026-04-06T22:00:00Z", new[] { 6, 18 }, "2026-04-07T05:00:00Z")]
+    // Single hour daily schedule
+    [InlineData("2026-04-06T10:00:00Z", new[] { 2 }, "2026-04-07T01:00:00Z")]
+    [InlineData("2026-02-27T00:30:00Z", new[] { 2 }, "2026-02-27T02:00:00Z")]
+    // DST spring-forward: last GMT day → first BST day
+    [InlineData("2026-03-28T18:00:00Z", new[] { 6, 18 }, "2026-03-29T05:00:00Z")]
+    // DST autumn-back: last BST day → first GMT day
+    [InlineData("2026-10-24T17:00:00Z", new[] { 6, 18 }, "2026-10-25T06:00:00Z")]
+    // Midnight schedule
+    [InlineData("2026-04-06T10:00:00Z", new[] { 0, 12 }, "2026-04-06T11:00:00Z")]
+    public void NextUkHourUtc_ShouldReturnNextUkHourSlotAsUtc(string previousIso, int[] ukHours, string expectedIso)
+    {
+        var previous = DateTime.Parse(previousIso, null, System.Globalization.DateTimeStyles.RoundtripKind);
+        var expected = DateTime.Parse(expectedIso, null, System.Globalization.DateTimeStyles.RoundtripKind);
+
+        var result = new Clock().NextUkHourUtc(previous, ukHours);
+
+        result.Should().Be(expected);
+    }
+
+    [Fact]
+    public void NextUkHourUtc_WithNoHours_ShouldThrow()
+    {
+        var act = () => new Clock().NextUkHourUtc(DateTime.UtcNow);
+
+        act.Should().Throw<ArgumentException>();
+    }
 }

--- a/Tests/UKSF.Api.Modpack.Tests/ScheduledActions/ActionRefreshSteamTokenTests.cs
+++ b/Tests/UKSF.Api.Modpack.Tests/ScheduledActions/ActionRefreshSteamTokenTests.cs
@@ -41,12 +41,13 @@ public class ActionRefreshSteamTokenTests
     }
 
     [Fact]
-    public void NextRun_ShouldBeToday6Am()
+    public void NextRunAfter_ShouldDelegateToClockHelperWith6And18()
     {
-        var today = new DateTime(2026, 2, 27);
-        _mockClock.Setup(x => x.UkToday()).Returns(today);
+        var previous = new DateTime(2026, 4, 6, 10, 0, 0, DateTimeKind.Utc);
+        var expected = new DateTime(2026, 4, 6, 17, 0, 0, DateTimeKind.Utc);
+        _mockClock.Setup(x => x.NextUkHourUtc(previous, new[] { 6, 18 })).Returns(expected);
 
-        _action.NextRun.Should().Be(today.AddHours(6));
+        _action.NextRunAfter(previous).Should().Be(expected);
     }
 
     [Fact]

--- a/UKSF.Api.ArmaServer/ScheduledActions/ActionCheckForServerUpdate.cs
+++ b/UKSF.Api.ArmaServer/ScheduledActions/ActionCheckForServerUpdate.cs
@@ -23,9 +23,11 @@ public class ActionCheckForServerUpdate(
 {
     private const string ActionName = nameof(ActionCheckForServerUpdate);
 
-    public override DateTime NextRun => clock.UkToday().AddHours(04).AddDays(1);
+    public override DateTime NextRun => NextRunAfter(clock.UtcNow());
     public override TimeSpan RunInterval => TimeSpan.FromHours(12);
     public override string Name => ActionName;
+
+    public override DateTime NextRunAfter(DateTime previous) => clock.NextUkHourUtc(previous, 4, 16);
 
     public override async Task Run(params object[] parameters)
     {

--- a/UKSF.Api.ArmaServer/ScheduledActions/ActionCleanupRunningServers.cs
+++ b/UKSF.Api.ArmaServer/ScheduledActions/ActionCleanupRunningServers.cs
@@ -20,9 +20,11 @@ public class ActionCleanupRunningServers(
 {
     private const string ActionName = nameof(ActionCleanupRunningServers);
 
-    public override DateTime NextRun => clock.UkToday().AddHours(02);
+    public override DateTime NextRun => NextRunAfter(clock.UtcNow());
     public override TimeSpan RunInterval => TimeSpan.FromDays(1);
     public override string Name => ActionName;
+
+    public override DateTime NextRunAfter(DateTime previous) => clock.NextUkHourUtc(previous, 2);
 
     public override async Task Run(params object[] parameters)
     {

--- a/UKSF.Api.Core/ScheduledActions/SelfCreatingScheduledAction.cs
+++ b/UKSF.Api.Core/ScheduledActions/SelfCreatingScheduledAction.cs
@@ -19,6 +19,11 @@ public class SelfCreatingScheduledAction : ISelfCreatingScheduledAction
     public virtual bool RunOnCreate => false;
     public virtual string Name => "UNNAMED ACTION";
 
+    public virtual DateTime NextRunAfter(DateTime previous)
+    {
+        return previous + RunInterval;
+    }
+
     public async Task CreateSelf()
     {
         if (_currentEnvironment.IsDevelopment())

--- a/UKSF.Api.Core/Services/Clock.cs
+++ b/UKSF.Api.Core/Services/Clock.cs
@@ -7,10 +7,13 @@ public interface IClock
     public DateTime UtcNow();
     public DateTime UkNow();
     public DateTime UkToday();
+    public DateTime NextUkHourUtc(DateTime previous, params int[] ukHours);
 }
 
 public class Clock : IClock
 {
+    private static readonly TimeZoneInfo UkTimeZone = TimeZoneInfo.FindSystemTimeZoneById("GMT Standard Time");
+
     public DateTime Now()
     {
         return DateTime.Now;
@@ -28,12 +31,24 @@ public class Clock : IClock
 
     public DateTime UkNow()
     {
-        var ukZone = TimeZoneInfo.FindSystemTimeZoneById("GMT Standard Time");
-        return TimeZoneInfo.ConvertTime(UtcNow(), ukZone);
+        return TimeZoneInfo.ConvertTime(UtcNow(), UkTimeZone);
     }
 
     public DateTime UkToday()
     {
         return UkNow().Date;
+    }
+
+    public DateTime NextUkHourUtc(DateTime previous, params int[] ukHours)
+    {
+        if (ukHours.Length == 0)
+        {
+            throw new ArgumentException("At least one UK hour must be provided", nameof(ukHours));
+        }
+
+        var previousUk = TimeZoneInfo.ConvertTimeFromUtc(DateTime.SpecifyKind(previous, DateTimeKind.Utc), UkTimeZone);
+        var sortedHours = ukHours.OrderBy(h => h).ToArray();
+        var nextHour = sortedHours.Cast<int?>().FirstOrDefault(h => h > previousUk.Hour) ?? sortedHours[0] + 24;
+        return TimeZoneInfo.ConvertTimeToUtc(previousUk.Date.AddHours(nextHour), UkTimeZone);
     }
 }

--- a/UKSF.Api.Core/Services/SchedulerService.cs
+++ b/UKSF.Api.Core/Services/SchedulerService.cs
@@ -3,6 +3,7 @@ using System.Text.Json;
 using UKSF.Api.Core.Context;
 using UKSF.Api.Core.Models;
 using UKSF.Api.Core.Models.Domain;
+using UKSF.Api.Core.ScheduledActions;
 
 namespace UKSF.Api.Core.Services;
 
@@ -97,7 +98,7 @@ public class SchedulerService(ISchedulerContext context, IScheduledActionFactory
                         var nowLessInterval = now - job.Interval;
                         while (job.Next < nowLessInterval)
                         {
-                            job.Next += job.Interval;
+                            job.Next = AdvanceNext(job);
                         }
                     }
                 }
@@ -113,7 +114,7 @@ public class SchedulerService(ISchedulerContext context, IScheduledActionFactory
 
                 if (job.Repeat)
                 {
-                    job.Next += job.Interval;
+                    job.Next = AdvanceNext(job);
                     await SetNext(job);
                     Schedule(job);
                 }
@@ -134,6 +135,12 @@ public class SchedulerService(ISchedulerContext context, IScheduledActionFactory
             existingToken.Cancel();
             existingToken.Dispose();
         }
+    }
+
+    private DateTime AdvanceNext(DomainScheduledJob job)
+    {
+        var action = scheduledActionFactory.GetScheduledAction(job.Action);
+        return action is SelfCreatingScheduledAction selfCreating ? selfCreating.NextRunAfter(job.Next) : job.Next + job.Interval;
     }
 
     private async Task SetNext(DomainScheduledJob job)

--- a/UKSF.Api.Integrations.Instagram/ScheduledActions/ActionInstagramImages.cs
+++ b/UKSF.Api.Integrations.Instagram/ScheduledActions/ActionInstagramImages.cs
@@ -24,10 +24,12 @@ public class ActionInstagramImages : SelfCreatingScheduledAction, IActionInstagr
         _clock = clock;
     }
 
-    public override DateTime NextRun => _clock.UkToday();
+    public override DateTime NextRun => NextRunAfter(_clock.UtcNow());
     public override TimeSpan RunInterval => TimeSpan.FromHours(12);
     public override bool RunOnCreate => true;
     public override string Name => ActionName;
+
+    public override DateTime NextRunAfter(DateTime previous) => _clock.NextUkHourUtc(previous, 0, 12);
 
     public override Task Run(params object[] parameters)
     {

--- a/UKSF.Api.Modpack/ScheduledActions/ActionRefreshSteamToken.cs
+++ b/UKSF.Api.Modpack/ScheduledActions/ActionRefreshSteamToken.cs
@@ -16,9 +16,11 @@ public class ActionRefreshSteamToken(
 {
     private const string ActionName = nameof(ActionRefreshSteamToken);
 
-    public override DateTime NextRun => clock.UkToday().AddHours(6);
+    public override DateTime NextRun => NextRunAfter(clock.UtcNow());
     public override TimeSpan RunInterval => TimeSpan.FromHours(12);
     public override string Name => ActionName;
+
+    public override DateTime NextRunAfter(DateTime previous) => clock.NextUkHourUtc(previous, 6, 18);
 
     public override async Task Run(params object[] parameters)
     {


### PR DESCRIPTION
## Summary

- Scheduled actions using `clock.UkToday()` returned a UK wall-clock `DateTime` that the scheduler then compared against `UtcNow`, so values were silently treated as UTC. Worked only in winter (UK==UTC); drifted by an hour every BST. The naive `+= interval` in `SchedulerService` meant the drift persisted across each DST flip.
- Added `IClock.NextUkHourUtc(previous, ukHours)` helper that converts UK wall-clock hour slots to UTC instants, plus a `NextRunAfter` virtual on `SelfCreatingScheduledAction` that the scheduler now calls each cycle so DST-aware actions self-correct.
- Migrated `ActionRefreshSteamToken` (06/18 UK), `ActionCleanupRunningServers` (02 UK), `ActionCheckForServerUpdate` (04/16 UK) and `ActionInstagramImages` (00/12 UK) to the helper.

## Test plan

- [x] `ClockTests.NextUkHourUtc_ShouldReturnNextUkHourSlotAsUtc` covers GMT, BST, single-hour, multi-hour, both DST transitions and midnight schedules
- [x] `ActionRefreshSteamTokenTests` updated to verify delegation to the helper
- [x] `SchedulerServiceTests` still pass (AdvanceNext falls back to `+= interval` for non-`SelfCreatingScheduledAction` jobs)
- [x] Full release build green
- [ ] After deploy each existing prod scheduledJobs row will fire once at the wrong hour, then self-correct via `NextRunAfter`

🤖 Generated with [Claude Code](https://claude.com/claude-code)